### PR TITLE
fix: enable type checking and improve typing

### DIFF
--- a/regex_spm/__init__.py
+++ b/regex_spm/__init__.py
@@ -4,15 +4,15 @@ from .regex_spm_match import RegexSpmMatch
 
 
 def search_in(string: str) -> RegexSpmMatch:
-  return RegexSpmMatch(string, _match_func=re.search)
+    return RegexSpmMatch(string, _match_func=re.search)
 
 
 def match_in(string: str) -> RegexSpmMatch:
-  return RegexSpmMatch(string, _match_func=re.match)
+    return RegexSpmMatch(string, _match_func=re.match)
 
 
 def fullmatch_in(string: str) -> RegexSpmMatch:
-  return RegexSpmMatch(string, _match_func=re.fullmatch)
+    return RegexSpmMatch(string, _match_func=re.fullmatch)
 
 
 __all__ = ['RegexSpmMatch', 'search_in', 'match_in', 'fullmatch_in']

--- a/regex_spm/regex_spm_match.py
+++ b/regex_spm/regex_spm_match.py
@@ -5,20 +5,20 @@ from typing import Callable
 
 @dataclass
 class RegexSpmMatch:
-  string: str
-  _match_func: Callable[[re.Pattern, str], re.Match]
-  match: re.Match | None = None
-
-  def __eq__(self, pattern: str | re.Pattern | tuple[str, int | re.RegexFlag]):
-    if isinstance(pattern, str):
-      pattern = re.compile(pattern)
-    elif isinstance(pattern, tuple):
-      pattern = re.compile(*pattern)
-    self.match = self._match_func(pattern, self.string)
-    return self.match is not None
-
-  def __getitem__(
-      self,
-      group: int | str | tuple[int, ...] | tuple[str, ...]
-  ) -> str | tuple[str, ...] | None:
-    return self.match[group]
+    string: str
+    _match_func: Callable[[re.Pattern, str], re.Match]
+    match: re.Match | None = None
+    
+    def __eq__(self, pattern: str | re.Pattern | tuple[str, int | re.RegexFlag]):
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
+        elif isinstance(pattern, tuple):
+            pattern = re.compile(*pattern)
+        self.match = self._match_func(pattern, self.string)
+        return self.match is not None
+    
+    def __getitem__(
+            self,
+            group: int | str | tuple[int, ...] | tuple[str, ...]
+    ) -> str | tuple[str, ...] | None:
+        return self.match[group]

--- a/regex_spm/regex_spm_match.py
+++ b/regex_spm/regex_spm_match.py
@@ -9,7 +9,7 @@ class RegexSpmMatch:
     _match_func: Callable[[re.Pattern, str], re.Match]
     match: re.Match | None = None
     
-    def __eq__(self, pattern: str | re.Pattern | tuple[str, int | re.RegexFlag]):
+    def __eq__(self, pattern: str | re.Pattern | tuple[str, int | re.RegexFlag]) -> bool:
         if isinstance(pattern, str):
             pattern = re.compile(pattern)
         elif isinstance(pattern, tuple):

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,24 @@
 from setuptools import setup
 
 with open('README.md', 'r') as f:
-  long_description = f.read()
+    long_description = f.read()
 
 setup(
-  name='regex_spm',
-  version='1.0.0',
-  packages=['regex_spm'],
-  url='https://github.com/aronhoff/regex_spm',
-  license='MIT',
-  author='aronhoffmann',
-  author_email='aron.m.hoff+pypy@gmail.com',
-  description='Enable Structural Pattern Matching for Python regular expressions',
-  long_description=long_description,
-  long_description_content_type='text/markdown',
-  classifiers=[
-    'Programming Language :: Python :: 3',
-    'License :: OSI Approved :: MIT License',
-    'Operating System :: OS Independent',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-  ],
-  python_requires='>=3.10',
+    name='regex_spm',
+    version='1.0.0',
+    packages=['regex_spm'],
+    url='https://github.com/aronhoff/regex_spm',
+    license='MIT',
+    author='aronhoffmann',
+    author_email='aron.m.hoff+pypy@gmail.com',
+    description='Enable Structural Pattern Matching for Python regular expressions',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    python_requires='>=3.10',
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='regex_spm',
-    version='1.0.0',
+    version='1.0.1',
     packages=['regex_spm'],
     package_data={'regex_spm': ['py.typed']},
     url='https://github.com/aronhoff/regex_spm',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     name='regex_spm',
     version='1.0.0',
     packages=['regex_spm'],
+    package_data={'regex_spm': ['py.typed']},
     url='https://github.com/aronhoff/regex_spm',
     license='MIT',
     author='aronhoffmann',

--- a/tests/test_spm.py
+++ b/tests/test_spm.py
@@ -10,7 +10,7 @@ class MyRegexes(ABC):
 
 
 class TestSpmSearch:
-    def test_spm_search_scenario_1(self):
+    def test_spm_search_scenario_1(self) -> None:
         match regex_spm.search_in('abcdef'):
             case MyRegexes.numbers:
                 assert False
@@ -19,14 +19,14 @@ class TestSpmSearch:
             case _:
                 assert False
     
-    def test_spm_search_scenario_2(self):
+    def test_spm_search_scenario_2(self) -> None:
         match regex_spm.search_in('abcd12345ef'):
             case MyRegexes.numbers as m:
                 assert m[0] == '12345'
             case _:
                 assert False
     
-    def test_spm_search_scenario_3(self):
+    def test_spm_search_scenario_3(self) -> None:
         match regex_spm.search_in('abcdededef'):
             case r'(de)+' as m:
                 assert m[0] == 'dedede'
@@ -36,7 +36,7 @@ class TestSpmSearch:
 
 
 class TestSpmMatch:
-    def test_spm_match_scenario_1(self):
+    def test_spm_match_scenario_1(self) -> None:
         match regex_spm.match_in('abcdef'):
             case MyRegexes.numbers:
                 assert False
@@ -45,7 +45,7 @@ class TestSpmMatch:
             case _:
                 assert False
     
-    def test_spm_match_scenario_2(self):
+    def test_spm_match_scenario_2(self) -> None:
         match regex_spm.match_in('abcd12345'):
             case MyRegexes.numbers:
                 assert False
@@ -54,7 +54,7 @@ class TestSpmMatch:
             case _:
                 assert False
     
-    def test_spm_match_scenario_3(self):
+    def test_spm_match_scenario_3(self) -> None:
         match regex_spm.match_in('abcdededef'):
             case r'abc(de)+' as m:
                 assert m[0] == 'abcdedede'
@@ -64,7 +64,7 @@ class TestSpmMatch:
 
 
 class TestSpmFullMatch:
-    def test_spm_fullmatch_scenario_1(self):
+    def test_spm_fullmatch_scenario_1(self) -> None:
         match regex_spm.fullmatch_in('abcdef'):
             case MyRegexes.numbers:
                 assert False
@@ -73,7 +73,7 @@ class TestSpmFullMatch:
             case _:
                 assert False
     
-    def test_spm_fullmatch_scenario_2(self):
+    def test_spm_fullmatch_scenario_2(self) -> None:
         match regex_spm.fullmatch_in('abcd12345'):
             case MyRegexes.numbers:
                 assert False
@@ -84,7 +84,7 @@ class TestSpmFullMatch:
             case _:
                 assert False
     
-    def test_spm_fullmatch_scenario_3(self):
+    def test_spm_fullmatch_scenario_3(self) -> None:
         match regex_spm.fullmatch_in('abcdededef'):
             case r'abc(de)+f' as m:
                 assert m[0] == 'abcdededef'

--- a/tests/test_spm.py
+++ b/tests/test_spm.py
@@ -5,89 +5,89 @@ import regex_spm
 
 
 class MyRegexes(ABC):
-  letters = re.compile(r'[a-zA-Z]+')
-  numbers = r'[0-9]+'
+    letters = re.compile(r'[a-zA-Z]+')
+    numbers = r'[0-9]+'
 
 
 class TestSpmSearch:
-  def test_spm_search_scenario_1(self):
-    match regex_spm.search_in('abcdef'):
-      case MyRegexes.numbers:
-        assert False
-      case MyRegexes.letters:
-        assert True
-      case _:
-        assert False
-
-  def test_spm_search_scenario_2(self):
-    match regex_spm.search_in('abcd12345ef'):
-      case MyRegexes.numbers as m:
-        assert m[0] == '12345'
-      case _:
-        assert False
-
-  def test_spm_search_scenario_3(self):
-    match regex_spm.search_in('abcdededef'):
-      case r'(de)+' as m:
-        assert m[0] == 'dedede'
-        assert m.match[1] == 'de'
-      case _:
-        assert False
+    def test_spm_search_scenario_1(self):
+        match regex_spm.search_in('abcdef'):
+            case MyRegexes.numbers:
+                assert False
+            case MyRegexes.letters:
+                assert True
+            case _:
+                assert False
+    
+    def test_spm_search_scenario_2(self):
+        match regex_spm.search_in('abcd12345ef'):
+            case MyRegexes.numbers as m:
+                assert m[0] == '12345'
+            case _:
+                assert False
+    
+    def test_spm_search_scenario_3(self):
+        match regex_spm.search_in('abcdededef'):
+            case r'(de)+' as m:
+                assert m[0] == 'dedede'
+                assert m.match[1] == 'de'
+            case _:
+                assert False
 
 
 class TestSpmMatch:
-  def test_spm_match_scenario_1(self):
-    match regex_spm.match_in('abcdef'):
-      case MyRegexes.numbers:
-        assert False
-      case MyRegexes.letters:
-        assert True
-      case _:
-        assert False
-
-  def test_spm_match_scenario_2(self):
-    match regex_spm.match_in('abcd12345'):
-      case MyRegexes.numbers:
-        assert False
-      case MyRegexes.letters as m:
-        assert m[0] == 'abcd'
-      case _:
-        assert False
-
-  def test_spm_match_scenario_3(self):
-    match regex_spm.match_in('abcdededef'):
-      case r'abc(de)+' as m:
-        assert m[0] == 'abcdedede'
-        assert m.match[1] == 'de'
-      case _:
-        assert False
+    def test_spm_match_scenario_1(self):
+        match regex_spm.match_in('abcdef'):
+            case MyRegexes.numbers:
+                assert False
+            case MyRegexes.letters:
+                assert True
+            case _:
+                assert False
+    
+    def test_spm_match_scenario_2(self):
+        match regex_spm.match_in('abcd12345'):
+            case MyRegexes.numbers:
+                assert False
+            case MyRegexes.letters as m:
+                assert m[0] == 'abcd'
+            case _:
+                assert False
+    
+    def test_spm_match_scenario_3(self):
+        match regex_spm.match_in('abcdededef'):
+            case r'abc(de)+' as m:
+                assert m[0] == 'abcdedede'
+                assert m.match[1] == 'de'
+            case _:
+                assert False
 
 
 class TestSpmFullMatch:
-  def test_spm_fullmatch_scenario_1(self):
-    match regex_spm.fullmatch_in('abcdef'):
-      case MyRegexes.numbers:
-        assert False
-      case MyRegexes.letters as m:
-        assert m[0] == 'abcdef'
-      case _:
-        assert False
-
-  def test_spm_fullmatch_scenario_2(self):
-    match regex_spm.fullmatch_in('abcd12345'):
-      case MyRegexes.numbers:
-        assert False
-      case MyRegexes.letters:
-        assert False
-      case '[a-z]+[0-9]+':
-        assert True
-      case _:
-        assert False
-
-  def test_spm_fullmatch_scenario_3(self):
-    match regex_spm.fullmatch_in('abcdededef'):
-      case r'abc(de)+f' as m:
-        assert m[0] == 'abcdededef'
-        assert m.match[1] == 'de'
-      case _:
-        assert False
+    def test_spm_fullmatch_scenario_1(self):
+        match regex_spm.fullmatch_in('abcdef'):
+            case MyRegexes.numbers:
+                assert False
+            case MyRegexes.letters as m:
+                assert m[0] == 'abcdef'
+            case _:
+                assert False
+    
+    def test_spm_fullmatch_scenario_2(self):
+        match regex_spm.fullmatch_in('abcd12345'):
+            case MyRegexes.numbers:
+                assert False
+            case MyRegexes.letters:
+                assert False
+            case '[a-z]+[0-9]+':
+                assert True
+            case _:
+                assert False
+    
+    def test_spm_fullmatch_scenario_3(self):
+        match regex_spm.fullmatch_in('abcdededef'):
+            case r'abc(de)+f' as m:
+                assert m[0] == 'abcdededef'
+                assert m.match[1] == 'de'
+            case _:
+                assert False


### PR DESCRIPTION
First of all, thank you for this awesome package! 🙂 🇭🇺 I've started [using it](https://github.com/gy-mate/kalauz/blob/499c454c8b0d2acdc03cd31a974b3b9567c79523/src/new_data_processors/SR_table_processors/companies/M%C3%81V.py#L357-L366) in a project of mine.

- Added a `py.typed` file according to [PEP 561](https://peps.python.org/pep-0561/) to enable type checking with e.g. `mypy`
  - Now `mypy` gives me the following error: _Skipping analyzing "regex_spm": module is installed, but missing library stubs or py.typed marker [import-untyped]_
- Added missing return type hints
- Indented files according to PEP 8 [E111](https://peps.python.org/pep-0008/#:~:text=Use%204%20spaces%20per%20indentation%20level.)
- Bumped version number to `1.0.1`